### PR TITLE
Use nova-echo v0.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "license": "MIT",
     "require": {
         "php": ">=7.1.0",
-        "coreproc/nova-echo": "^0.1.0",
+        "coreproc/nova-echo": "^0.2.0",
         "pusher/pusher-php-server": "^3.2"
     },
     "autoload": {


### PR DESCRIPTION
To make use of [added wssPort](https://github.com/CoreProc/nova-echo/pull/2) of nova-echo pkg we need to update the dependency in this one.